### PR TITLE
使用 rime 的 logo ㄓ 替代 韻

### DIFF
--- a/src/rime.conf.in
+++ b/src/rime.conf.in
@@ -1,7 +1,7 @@
 [InputMethod]
 Name=Rime
 Icon=fcitx-rime
-Label=韻
+Label=ㄓ
 LangCode=zh_TW
 Addon=rime
 Configurable=True


### PR DESCRIPTION
感觉直接使用rime的logo  'ㄓ' 比 '韻' 更好
ㄓ 是一个注音符号