### PR TITLE
support switches in status area

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/*
 *.orig
 tags
 astyle.sh
+.cache

--- a/src/rimeengine.cpp
+++ b/src/rimeengine.cpp
@@ -437,7 +437,7 @@ void RimeEngine::refreshStatusArea(InputContext &ic) {
     rimeState->getStatus([&currentSchema](const RimeStatus &status) {
         currentSchema = status.schema_id ? status.schema_id : "";
     });
-    if (!currentSchema.length()) {
+    if (currentSchema.empty()) {
         return;
     }
     RimeConfig config{};

--- a/src/rimeengine.cpp
+++ b/src/rimeengine.cpp
@@ -509,7 +509,7 @@ void RimeEngine::refreshStatusArea(RimeSessionId session) {
         [this, session](InputContext *ic) {
             if (auto state = this->state(ic)) {
                 // After a deployment, param is 0, refresh all
-                if (!session || state->session() == session) {
+                if (!session || state->session(false) == session) {
                     refreshStatusArea(*ic);
                 }
             }

--- a/src/rimeengine.cpp
+++ b/src/rimeengine.cpp
@@ -239,6 +239,7 @@ RimeEngine::RimeEngine(Instance *instance)
                                                      imAction_.get());
     imAction_->setMenu(&schemaMenu_);
     eventDispatcher_.attach(&instance_->eventLoop());
+    separatorAction_.setSeparator(true);
     deployAction_.setIcon("fcitx-rime-deploy");
     deployAction_.setShortText(_("Deploy"));
     deployAction_.connect<SimpleAction::Activated>([this](InputContext *ic) {
@@ -263,6 +264,9 @@ RimeEngine::RimeEngine(Instance *instance)
     });
     instance_->userInterfaceManager().registerAction("fcitx-rime-sync",
                                                      &syncAction_);
+    schemaMenu_.addAction(&separatorAction_);
+    schemaMenu_.addAction(&deployAction_);
+    schemaMenu_.addAction(&syncAction_);
     globalConfigReloadHandle_ = instance_->watchEvent(
         EventType::GlobalConfigReloaded, EventWatcherPhase::Default,
         [this](Event &) {
@@ -710,8 +714,6 @@ void RimeEngine::updateSchemaMenu() {
         return;
     }
 
-    schemaMenu_.addAction(&deployAction_);
-    schemaMenu_.addAction(&syncAction_);
     schemActions_.clear();
     RimeSchemaList list;
     list.size = 0;
@@ -726,7 +728,7 @@ void RimeEngine::updateSchemaMenu() {
                 imAction_->update(ic);
             });
         instance_->userInterfaceManager().registerAction(&schemActions_.back());
-        schemaMenu_.addAction(&schemActions_.back());
+        schemaMenu_.insertAction(&separatorAction_, &schemActions_.back());
         for (size_t i = 0; i < list.size; i++) {
             schemActions_.emplace_back();
             std::string schemaId = list.list[i].schema_id;
@@ -739,7 +741,7 @@ void RimeEngine::updateSchemaMenu() {
                     imAction_->update(ic);
                 });
             instance_->userInterfaceManager().registerAction(&schemaAction);
-            schemaMenu_.addAction(&schemaAction);
+            schemaMenu_.insertAction(&separatorAction_, &schemaAction);
         }
         api_->free_schema_list(&list);
     }

--- a/src/rimeengine.cpp
+++ b/src/rimeengine.cpp
@@ -454,6 +454,11 @@ void RimeEngine::updateConfig() {
 }
 
 void RimeEngine::refreshStatusArea(InputContext &ic) {
+    // prevent modifying status area owned by other ime
+    // e.g. keyboard-us when typing password
+    if (instance_->inputMethodEntry(&ic)->uniqueName() != "rime") {
+        return;
+    }
     optionActions_.clear();
     auto &statusArea = ic.statusArea();
     statusArea.clearGroup(StatusGroup::InputMethod);

--- a/src/rimeengine.h
+++ b/src/rimeengine.h
@@ -139,6 +139,7 @@ private:
     FactoryFor<RimeState> factory_;
 
     std::unique_ptr<Action> imAction_;
+    SimpleAction separatorAction_;
     SimpleAction deployAction_;
     SimpleAction syncAction_;
 

--- a/src/rimeengine.h
+++ b/src/rimeengine.h
@@ -123,9 +123,12 @@ private:
     void deploy();
     void sync();
     void updateSchemaMenu();
-    void notify(const std::string &type, const std::string &value);
+    void notify(RimeSessionId session, const std::string &type,
+                const std::string &value);
     void releaseAllSession();
     void updateAppOptions();
+    void refreshStatusArea(InputContext &ic);
+    void refreshStatusArea(RimeSessionId session);
 
     IconTheme theme_;
     Instance *instance_;
@@ -146,6 +149,7 @@ private:
     FCITX_ADDON_DEPENDENCY_LOADER(notifications, instance_->addonManager());
 
     std::list<SimpleAction> schemActions_;
+    std::list<std::unique_ptr<Action>> optionActions_;
     Menu schemaMenu_;
 #ifdef FCITX_RIME_LOAD_PLUGIN
     std::unordered_map<std::string, Library> pluginPool_;

--- a/src/rimestate.cpp
+++ b/src/rimestate.cpp
@@ -85,7 +85,7 @@ void RimeState::setLatinMode(bool latin) {
     if (!api || api->is_maintenance_mode()) {
         return;
     }
-    api->set_option(session(), "ascii_mode", latin);
+    api->set_option(session(), RIME_ASCII_MODE, latin);
 }
 
 void RimeState::selectSchema(const std::string &schema) {
@@ -93,7 +93,7 @@ void RimeState::selectSchema(const std::string &schema) {
     if (!api || api->is_maintenance_mode()) {
         return;
     }
-    api->set_option(session(), "ascii_mode", false);
+    api->set_option(session(), RIME_ASCII_MODE, false);
     api->select_schema(session(), schema.data());
 }
 

--- a/src/rimestate.cpp
+++ b/src/rimestate.cpp
@@ -30,8 +30,8 @@ RimeState::RimeState(RimeEngine *engine, InputContext &ic)
 
 RimeState::~RimeState() {}
 
-RimeSessionId RimeState::session() {
-    if (!session_) {
+RimeSessionId RimeState::session(bool requestNewSession) {
+    if (!session_ && requestNewSession) {
         session_ = engine_->sessionPool().requestSession(&ic_);
     }
     if (!session_) {

--- a/src/rimestate.h
+++ b/src/rimestate.h
@@ -13,6 +13,8 @@
 #include <memory>
 #include <rime_api.h>
 
+#define RIME_ASCII_MODE "ascii_mode"
+
 namespace fcitx {
 
 class RimeEngine;

--- a/src/rimestate.h
+++ b/src/rimestate.h
@@ -39,7 +39,7 @@ public:
     std::string subModeLabel();
     void setLatinMode(bool latin);
     void selectSchema(const std::string &schemaId);
-    RimeSessionId session();
+    RimeSessionId session(bool requestNewSession = true);
 
 private:
     std::string lastMode_;


### PR DESCRIPTION
Tested scenarios:
* Changing schema ([luna_pinyin](https://github.com/rime/rime-luna-pinyin/blob/79aeae200a7370720be98232844c0715f277e1c0/luna_pinyin.schema.yaml#L20-L29), [jyut6ping3](https://github.com/rime/rime-cantonese/blob/e3c6b17e638ac8a9aeab4d5852e5909b049c5ab3/jyut6ping3.schema.yaml#L31-L49)) in F4/UI updates status area.
* Changing option (trad/simp for luna_pinyin, 4 variants for jyut6ping3) in F4/UI updates status area.
* Deployment after removing current schema_id in `default.yaml` updates status area.

![Screenshot from 2023-10-02 00-10-48](https://github.com/fcitx/fcitx5-rime/assets/26783539/a53e9b78-259a-4dee-8298-58d0226a12d3)
![photo_2023-10-02_23-05-02](https://github.com/fcitx/fcitx5-rime/assets/26783539/87bc8294-28f4-40c3-8f21-0806ca269bb0)
