### PR TITLE
Allow loading plugins in librime static library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,11 @@ message(STATUS "Precompiler macro RIME_DATA_DIR is set to \"${RIME_DATA_DIR}\"")
 add_definitions(-DRIME_DATA_DIR="${RIME_DATA_DIR}")
 add_definitions(-DFCITX_GETTEXT_DOMAIN=\"fcitx5-rime\")
 add_definitions(-DFCITX_RIME_VERSION=\"${PROJECT_VERSION}\")
+# allow loading plugins in librime static library.
+# should be a comma separated list. eg. lua,octagram
+if (DEFINED FCITX_RIME_STATIC_PLUGINS)
+    add_definitions(-DFCITX_RIME_STATIC_PLUGINS=${FCITX_RIME_STATIC_PLUGINS})
+endif()
 fcitx5_add_i18n_definition()
 
 include("${FCITX_INSTALL_CMAKECONFIG_DIR}/Fcitx5Utils/Fcitx5CompilerSettings.cmake")


### PR DESCRIPTION
Add a new cmake option `FCITX_RIME_STATIC_PLUGINS`, to load librime plugins in its static library.

Usage example:

```cmake
# import librime static library somehow, it shoud be compiled with plugins
set(RIME_TARGET Rime_static)
set(FCITX_RIME_STATIC_PLUGINS "lua,octagram")
add_subdirectory(fcitx5-rime)
```

ref: https://github.com/osfans/trime/blob/cbe811a11db6d70a94f30934059456f858bf1236/app/src/main/jni/librime_jni/rime_jni.cc#L10-L18