### PR TITLE
Avoid redundant releaseAllSession() call.

### DIFF
--- a/src/rimeengine.cpp
+++ b/src/rimeengine.cpp
@@ -689,9 +689,12 @@ std::string RimeEngine::subModeIconImpl(const InputMethodEntry &,
     return result;
 }
 
-void RimeEngine::releaseAllSession() {
-    instance_->inputContextManager().foreach([this](InputContext *ic) {
+void RimeEngine::releaseAllSession(const bool snapshot) {
+    instance_->inputContextManager().foreach([&](InputContext *ic) {
         if (auto state = this->state(ic)) {
+            if (snapshot) {
+                state->snapshot();
+            }
             state->release();
         }
         return true;
@@ -707,16 +710,8 @@ void RimeEngine::deploy() {
 
 void RimeEngine::sync() {
     RIME_DEBUG() << "Rime Sync user data";
-
-    instance_->inputContextManager().foreach([this](InputContext *ic) {
-        if (auto state = this->state(ic)) {
-            state->snapshot();
-            state->release();
-        }
-        return true;
-    });
+    releaseAllSession(true);
     api_->sync_user_data();
-    releaseAllSession();
 }
 
 void RimeEngine::updateActionsForSchema(const std::string &schema) {

--- a/src/rimeengine.h
+++ b/src/rimeengine.h
@@ -136,7 +136,7 @@ private:
     void updateActionsForSchema(const std::string &schema);
     void notify(RimeSessionId session, const std::string &type,
                 const std::string &value);
-    void releaseAllSession();
+    void releaseAllSession(const bool snapshot = false);
     void updateAppOptions();
     void refreshStatusArea(InputContext &ic);
     void refreshStatusArea(RimeSessionId session);

--- a/src/rimestate.cpp
+++ b/src/rimestate.cpp
@@ -310,7 +310,9 @@ void RimeState::updateUI(InputContext *ic, bool keyRelease) {
     }
 }
 
-void RimeState::release() { session_.reset(); }
+void RimeState::release() {
+    session_.reset();
+}
 
 void RimeState::commitPreedit(InputContext *ic) {
     if (auto api = engine_->api()) {
@@ -341,7 +343,6 @@ void RimeState::restore() {
     if (savedCurrentSchema_.empty()) {
         return;
     }
-    FCITX_INFO() << engine_->schemas();
     if (!engine_->schemas().count(savedCurrentSchema_)) {
         return;
     }


### PR DESCRIPTION
https://github.com/fcitx/fcitx5-rime/blob/12a04bbcbd33e14b4af98e8ddf898dcbd7da76ef/src/rimeengine.cpp#L711-L717

is effectively `releaseAllSession()` but with `state->snapshot()`, and it calls `releaseAllSession()` again afterwards.

https://github.com/fcitx/fcitx5-rime/blob/12a04bbcbd33e14b4af98e8ddf898dcbd7da76ef/src/rimeengine.cpp#L719

