### PR TITLE
Call refreshStatusArea in updateConfig.

### DIFF
--- a/src/rimeengine.cpp
+++ b/src/rimeengine.cpp
@@ -468,6 +468,7 @@ void RimeEngine::updateConfig() {
     instance_->inputContextManager().registerProperty("rimeState", &factory_);
     updateSchemaMenu();
     refreshSessionPoolPolicy();
+    refreshStatusArea(0);
 }
 
 void RimeEngine::refreshStatusArea(InputContext &ic) {


### PR DESCRIPTION
`RimeEngine::updateConfig()` calls `RimeEngine::updateSchemaMenu()` which would clear both `schemaActions_` and `optionActions_`. Re-populate `optionActions_` is needed afterwards.

https://github.com/fcitx/fcitx5-rime/blob/7568f67362cfbad17653694c123f439f2ff69192/src/rimeengine.cpp#L756-L758

This would fix empty status area after clicking "Reload Config" on Android (see 0:08 of the video in https://github.com/fcitx/fcitx5-rime/issues/76)

![image](https://github.com/fcitx/fcitx5-rime/assets/13914967/3f228567-3993-4a56-b068-a0dfdac2556f)
