### PR TITLE
Make RimeEngine::firstRun_ static.

### DIFF
--- a/src/rimeengine.cpp
+++ b/src/rimeengine.cpp
@@ -246,6 +246,8 @@ private:
     Menu menu_;
 };
 
+bool RimeEngine::firstRun_ = true;
+
 RimeEngine::RimeEngine(Instance *instance)
     : instance_(instance), api_(EnsureRimeApi()),
       factory_([this](InputContext &ic) { return new RimeState(this, ic); }),

--- a/src/rimeengine.h
+++ b/src/rimeengine.h
@@ -149,7 +149,7 @@ private:
     Instance *instance_;
     EventDispatcher eventDispatcher_;
     rime_api_t *api_;
-    bool firstRun_ = true;
+    static bool firstRun_;
     uint64_t blockNotificationBefore_ = 0;
     FactoryFor<RimeState> factory_;
 


### PR DESCRIPTION
Rime uses glog, which can only be initialized once, otherwise it would abort with message:

```
Check failed: !IsGoogleLoggingInitialized() You called InitGoogleLogging() twice!
```

Since glog uses static storage for it's "Initialized" flag, we should use static storage for `firstRun_` too.

https://github.com/google/glog/blob/b33e3bad4c46c8a6345525fd822af355e5ef9446/src/utilities.cc#L69-L73