### PR TITLE
distinguish candidate text and comment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(ECMSetupVersion)
 include(ECMUninstallTarget)
 
 find_package(Gettext REQUIRED)
-find_package(Fcitx5Core 5.1.7 REQUIRED)
+find_package(Fcitx5Core 5.1.8 REQUIRED)
 find_package(Fcitx5Module REQUIRED COMPONENTS Notifications)
 find_package(PkgConfig REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(ECMSetupVersion)
 include(ECMUninstallTarget)
 
 find_package(Gettext REQUIRED)
-find_package(Fcitx5Core 5.1.8 REQUIRED)
+find_package(Fcitx5Core 5.1.9 REQUIRED)
 find_package(Fcitx5Module REQUIRED COMPONENTS Notifications)
 find_package(PkgConfig REQUIRED)
 

--- a/src/rimecandidate.cpp
+++ b/src/rimecandidate.cpp
@@ -19,13 +19,9 @@ RimeCandidateWord::RimeCandidateWord(RimeEngine *engine,
                                      const RimeCandidate &candidate, KeySym sym,
                                      int idx)
     : CandidateWord(), engine_(engine), sym_(sym), idx_(idx) {
-    Text text;
-    text.append(std::string(candidate.text));
-    setText(text);
-    if (candidate.comment && strlen(candidate.comment)) {
-        Text comment;
-        comment.append(std::string(candidate.comment));
-        setComment(comment);
+    setText(Text{candidate.text});
+    if (candidate.comment && candidate.comment[0]) {
+        setComment(Text{candidate.comment});
     }
 }
 
@@ -46,13 +42,10 @@ RimeGlobalCandidateWord::RimeGlobalCandidateWord(RimeEngine *engine,
                                                  const RimeCandidate &candidate,
                                                  int idx)
     : CandidateWord(), engine_(engine), idx_(idx) {
-    Text text;
-    text.append(std::string(candidate.text));
-    if (candidate.comment && strlen(candidate.comment)) {
-        text.append(" ");
-        text.append(std::string(candidate.comment));
+    setText(Text{candidate.text});
+    if (candidate.comment && candidate.comment[0]) {
+        setComment(Text{candidate.comment});
     }
-    setText(text);
 }
 
 void RimeGlobalCandidateWord::select(InputContext *inputContext) const {

--- a/src/rimecandidate.cpp
+++ b/src/rimecandidate.cpp
@@ -21,11 +21,12 @@ RimeCandidateWord::RimeCandidateWord(RimeEngine *engine,
     : CandidateWord(), engine_(engine), sym_(sym), idx_(idx) {
     Text text;
     text.append(std::string(candidate.text));
-    if (candidate.comment && strlen(candidate.comment)) {
-        text.append(" ");
-        text.append(std::string(candidate.comment));
-    }
     setText(text);
+    if (candidate.comment && strlen(candidate.comment)) {
+        Text comment;
+        comment.append(std::string(candidate.comment));
+        setComment(comment);
+    }
 }
 
 void RimeCandidateWord::select(InputContext *inputContext) const {


### PR DESCRIPTION
Make use of the new `setComment`.
The correct version should be 5.1.9 but I think that won't pass CI now.