### PR TITLE
Work around unexpected commit preview persistency

### DIFF
--- a/src/rimestate.cpp
+++ b/src/rimestate.cpp
@@ -258,8 +258,20 @@ void RimeState::updatePreedit(InputContext *ic, const RimeContext &context) {
             context, TextFormatFlag::NoFlag, TextFormatFlag::NoFlag));
         break;
     case PreeditMode::CommitPreview: {
-        ic->inputPanel().setPreedit(preeditFromRimeContext(
-            context, TextFormatFlag::NoFlag, TextFormatFlag::NoFlag));
+        Text composingPreedit = preeditFromRimeContext(
+            context, TextFormatFlag::NoFlag, TextFormatFlag::NoFlag);
+        ic->inputPanel().setPreedit(composingPreedit);
+        /*
+         * librime sometimes does not clear commit_text_preview after clearing
+         * composition, so we need to check if the composition is empty.
+         * However, the procedure can be simplifed, as composingPreedit will
+         * also be empty in such a case, so we can safely check its emptiness
+         * and use it as the empty preedit we expect.
+         */
+        if (composingPreedit.empty()) {
+            ic->inputPanel().setClientPreedit(composingPreedit);
+            break;
+        }
         if (context.commit_text_preview) {
             Text clientPreedit;
             clientPreedit.append(context.commit_text_preview,


### PR DESCRIPTION
Fixes #82 #83

I can confirm that @wengxt's statement `主要原因是 preedit 在 key release 仍然能获取到 commit preview ，这部分我认为是 rime 的 bug` is true.

However, since librime maintainers do not consider it a bug (refer to https://github.com/rime/librime/issues/761 and https://github.com/rime/librime/issues/772#issuecomment-1929921141), the best we can do is to work around it at the fcitx5-rime side.