### PR TITLE
Set program name to client_app property

### DIFF
--- a/src/rimeengine.cpp
+++ b/src/rimeengine.cpp
@@ -11,24 +11,40 @@
 #include <cstring>
 #include <ctime>
 #include <dirent.h>
+#include <exception>
+#include <fcitx-config/iniparser.h>
+#include <fcitx-config/rawconfig.h>
 #include <fcitx-utils/event.h>
 #include <fcitx-utils/fs.h>
 #include <fcitx-utils/i18n.h>
 #include <fcitx-utils/log.h>
+#include <fcitx-utils/macros.h>
 #include <fcitx-utils/misc.h>
 #include <fcitx-utils/standardpath.h>
 #include <fcitx-utils/stringutils.h>
+#include <fcitx/action.h>
+#include <fcitx/addoninstance.h>
 #include <fcitx/candidatelist.h>
+#include <fcitx/event.h>
 #include <fcitx/inputcontext.h>
 #include <fcitx/inputcontextmanager.h>
+#include <fcitx/inputmethodentry.h>
 #include <fcitx/inputpanel.h>
+#include <fcitx/instance.h>
+#include <fcitx/menu.h>
 #include <fcitx/statusarea.h>
 #include <fcitx/userinterface.h>
 #include <fcitx/userinterfacemanager.h>
+#include <list>
+#include <memory>
 #include <optional>
 #include <rime_api.h>
 #include <stdexcept>
 #include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 FCITX_DEFINE_LOG_CATEGORY(rime, "rime");
 
@@ -593,6 +609,9 @@ void RimeEngine::activate(const InputMethodEntry & /*entry*/,
                           InputContextEvent &event) {
     auto *ic = event.inputContext();
     refreshStatusArea(*ic);
+    if (auto *state = this->state(ic)) {
+        state->activate();
+    }
 }
 
 void RimeEngine::deactivate(const InputMethodEntry &entry,

--- a/src/rimesession.cpp
+++ b/src/rimesession.cpp
@@ -6,8 +6,10 @@
  */
 #include "rimesession.h"
 #include "rimeengine.h"
+#include <cassert>
 #include <fcitx-utils/charutils.h>
 #include <fcitx-utils/log.h>
+#include <fcitx-utils/macros.h>
 #include <fcitx-utils/stringutils.h>
 #include <fcitx/inputcontext.h>
 #include <fcitx/inputcontextmanager.h>
@@ -30,6 +32,8 @@ RimeSessionHolder::RimeSessionHolder(RimeSessionPool *pool,
         throw std::runtime_error("Failed to create session.");
     }
 
+    setProgramName(program);
+
     if (program.empty()) {
         return;
     }
@@ -51,6 +55,17 @@ RimeSessionHolder::~RimeSessionHolder() {
     if (!key_.empty()) {
         pool_->unregisterSession(key_);
     }
+}
+
+void RimeSessionHolder::setProgramName(const std::string &program) {
+    // set_property will trigger property change notification, which is a little
+    // bit annoying, so don't set it, if the value is not changed.
+    if (program == currentProgram_) {
+        return;
+    }
+
+    currentProgram_ = program;
+    pool_->engine()->api()->set_property(id_, "client_app", program.data());
 }
 
 #if 0

--- a/src/rimesession.h
+++ b/src/rimesession.h
@@ -9,10 +9,13 @@
 
 #include <fcitx-utils/log.h>
 #include <fcitx-utils/macros.h>
+#include <fcitx/inputcontext.h>
 #include <fcitx/inputcontextmanager.h>
 #include <memory>
 #include <rime_api.h>
 #include <string>
+#include <tuple>
+#include <unordered_map>
 
 namespace fcitx {
 
@@ -31,10 +34,13 @@ public:
 
     RimeSessionId id() const { return id_; }
 
+    void setProgramName(const std::string &program);
+
 private:
     RimeSessionPool *pool_;
     RimeSessionId id_ = 0;
     std::string key_;
+    std::string currentProgram_;
 };
 
 class RimeSessionPool {

--- a/src/rimestate.cpp
+++ b/src/rimestate.cpp
@@ -7,6 +7,7 @@
 #include "rimestate.h"
 #include "rimecandidate.h"
 #include "rimeengine.h"
+#include "rimesession.h"
 #include <cstdint>
 #include <fcitx-utils/capabilityflags.h>
 #include <fcitx-utils/i18n.h>
@@ -18,6 +19,7 @@
 #include <fcitx/candidatelist.h>
 #include <fcitx/event.h>
 #include <fcitx/inputcontext.h>
+#include <fcitx/inputcontextmanager.h>
 #include <fcitx/inputpanel.h>
 #include <fcitx/text.h>
 #include <fcitx/userinterface.h>
@@ -69,6 +71,8 @@ void RimeState::clear() {
         engine_->api()->clear_composition(session);
     }
 }
+
+void RimeState::activate() { maybeSyncProgramNameToSession(); }
 
 std::string RimeState::subMode() {
     std::string result;
@@ -158,6 +162,7 @@ void RimeState::keyEvent(KeyEvent &event) {
         return;
     }
 
+    maybeSyncProgramNameToSession();
     lastMode_ = subMode();
     auto states = event.rawKey().states() &
                   KeyStates{KeyState::Mod1, KeyState::CapsLock, KeyState::Shift,
@@ -448,6 +453,19 @@ void RimeState::restore() {
         } else {
             engine_->api()->set_option(session(), option.c_str(), true);
         }
+    }
+}
+
+void RimeState::maybeSyncProgramNameToSession() {
+    // The program name is guranteed to be const through the Input Context
+    // lifetime. There is no need to update it if the policy is not "All".
+    if (engine_->sessionPool().propertyPropagatePolicy() !=
+        PropertyPropagatePolicy::All) {
+        return;
+    }
+
+    if (session_) {
+        session_->setProgramName(ic_.program());
     }
 }
 

--- a/src/rimestate.h
+++ b/src/rimestate.h
@@ -7,11 +7,15 @@
 #define _FCITX_RIMESTATE_H_
 
 #include "rimesession.h"
+#include <fcitx/event.h>
 #include <fcitx/globalconfig.h>
 #include <fcitx/inputcontextmanager.h>
 #include <fcitx/inputcontextproperty.h>
+#include <functional>
 #include <memory>
 #include <rime_api.h>
+#include <string>
+#include <vector>
 
 #define RIME_ASCII_MODE "ascii_mode"
 
@@ -26,6 +30,7 @@ public:
     virtual ~RimeState();
 
     void clear();
+    void activate();
     void keyEvent(KeyEvent &event);
 #ifndef FCITX_RIME_NO_SELECT_CANDIDATE
     void selectCandidate(InputContext *inputContext, int idx, bool global);
@@ -46,6 +51,8 @@ public:
     void restore();
 
 private:
+    void maybeSyncProgramNameToSession();
+
     std::string lastMode_;
     RimeEngine *engine_;
     InputContext &ic_;


### PR DESCRIPTION
client_app is the property name used by Rime/Weasel. This should allow other component of rime to be able to get the application name of current session.