### PR TITLE
Support setting shared data via XDG_DATA_DIRS and XDG_DATA_HOME

### DIFF
--- a/src/rimeengine.cpp
+++ b/src/rimeengine.cpp
@@ -175,17 +175,27 @@ RimeEngine::RimeEngine(Instance *instance)
     : instance_(instance), api_(EnsureRimeApi()),
       factory_([this](InputContext &ic) { return new RimeState(this, ic); }),
       sessionPool_(this, getSharedStatePolicy()) {
-    if constexpr (isAndroid() || isApple()) {
-        const auto &sp = fcitx::StandardPath::global();
-        std::string defaultYaml = sp.locate(fcitx::StandardPath::Type::Data,
-                                            "rime-data/default.yaml");
-        if (defaultYaml.empty()) {
+
+    this->sharedDataDir_ = []() -> std::string {
+        // First we detect the shared data directory via XDG_DATA_DIRS and
+        // XDG_DATA_HOME, if not found, we use RIEM_DATA_DIR as fallback. So
+        // that users can use XDG_DATA_DIRS to override the shared data.
+
+        std::string pathToDefault = fcitx::StandardPath::global().locate(
+            fcitx::StandardPath::Type::Data, "rime-data/default.yaml");
+
+        // Use RIEM_DATA_DIR as fallback
+        if (pathToDefault.empty() && fs::isreg(RIME_DATA_DIR "default.yaml")) {
+            pathToDefault = RIME_DATA_DIR "default.yaml";
+        }
+
+        // If we can't detect the shared data directory, we throw an exception
+        if (pathToDefault.empty()) {
             throw std::runtime_error("Fail to locate shared data directory");
         }
-        sharedDataDir_ = fcitx::fs::dirName(defaultYaml);
-    } else {
-        sharedDataDir_ = RIME_DATA_DIR;
-    }
+        return fcitx::fs::dirName(pathToDefault);
+    }();
+
     imAction_ = std::make_unique<IMAction>(this);
     instance_->userInterfaceManager().registerAction("fcitx-rime-im",
                                                      imAction_.get());


### PR DESCRIPTION
In this PR, fcitx5-rime detect shared data using following logic:

If fcitx5-rime can find `rime-data/default.yaml` in `$XDG_DATA_HOME` or `$XDG_DATA_DIRS` (using `fcitx::fs::StandardPath::scanDirectories`), it will use it . Otherwise, it use `RIME_DATA_DIR` specified during build time as fallback.