### PR TITLE
split AddonFactory into a separate file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ set(RIME_SOURCES
     rimecandidate.cpp
     rimesession.cpp
     rimeaction.cpp
+    rimefactory.cpp
 )
 
 set(RIME_LINK_LIBRARIES

--- a/src/rimeengine.cpp
+++ b/src/rimeengine.cpp
@@ -793,5 +793,3 @@ PropertyPropagatePolicy RimeEngine::getSharedStatePolicy() {
 }
 
 } // namespace fcitx
-
-FCITX_ADDON_FACTORY(fcitx::RimeEngineFactory)

--- a/src/rimeengine.h
+++ b/src/rimeengine.h
@@ -24,7 +24,6 @@
 #include <fcitx-utils/standardpath.h>
 #include <fcitx-utils/stringutils.h>
 #include <fcitx/action.h>
-#include <fcitx/addonfactory.h>
 #include <fcitx/addoninstance.h>
 #include <fcitx/addonmanager.h>
 #include <fcitx/event.h>
@@ -233,14 +232,6 @@ private:
     RimeSessionPool sessionPool_;
     std::thread::id mainThreadId_ = std::this_thread::get_id();
     RimeState *currentKeyEventState_ = nullptr;
-};
-
-class RimeEngineFactory : public AddonFactory {
-public:
-    AddonInstance *create(AddonManager *manager) override {
-        registerDomain("fcitx5-rime", FCITX_INSTALL_LOCALEDIR);
-        return new RimeEngine(manager->instance());
-    }
 };
 } // namespace fcitx
 

--- a/src/rimefactory.cpp
+++ b/src/rimefactory.cpp
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2024 CSSlayer <wengxt@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#include "rimefactory.h"
+#include "rimeengine.h"
+#include <fcitx-utils/i18n.h>
+
+namespace fcitx {
+
+AddonInstance *RimeEngineFactory::create(AddonManager *manager) {
+    registerDomain("fcitx5-rime", FCITX_INSTALL_LOCALEDIR);
+    return new RimeEngine(manager->instance());
+}
+
+} // namespace fcitx
+
+FCITX_ADDON_FACTORY(fcitx::RimeEngineFactory)

--- a/src/rimefactory.h
+++ b/src/rimefactory.h
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2024 CSSlayer <wengxt@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+#ifndef _FCITX_RIMEFACTORY_H_
+#define _FCITX_RIMEFACTORY_H_
+
+#include <fcitx/addonfactory.h>
+
+namespace fcitx {
+
+class RimeEngineFactory : public AddonFactory {
+public:
+    AddonInstance *create(AddonManager *manager) override;
+};
+
+} // namespace fcitx
+
+#endif


### PR DESCRIPTION
So that the target that includes "rimefactory.h" doesn't need to have rime_api.h in include search paths.