### PR TITLE
don't fix preedit cursor at the beginning on web

### DIFF
--- a/src/rimeengine.h
+++ b/src/rimeengine.h
@@ -88,7 +88,7 @@ FCITX_CONFIGURATION(
     Option<bool> preeditCursorPositionAtBeginning{
         this, "PreeditCursorPositionAtBeginning",
         _("Fix embedded preedit cursor at the beginning of the preedit"),
-        !isAndroid() && !isApple()};
+        !isAndroid() && !isApple() && !isEmscripten()};
     OptionWithAnnotation<SwitchInputMethodBehavior,
                          SwitchInputMethodBehaviorI18NAnnotation>
         switchInputMethodBehavior{


### PR DESCRIPTION
On web we know every position's coordinates with the help of https://github.com/component/textarea-caret-position