### PR TITLE
fix action label empty for multi-switch without reset

### DIFF
--- a/src/rimeaction.cpp
+++ b/src/rimeaction.cpp
@@ -122,7 +122,7 @@ SelectAction::SelectAction(RimeEngine *engine, std::string_view schema,
 std::string SelectAction::shortText(InputContext *ic) const {
     auto *state = engine_->state(ic);
     auto *api = engine_->api();
-    if (!state) {
+    if (!state || texts_.empty()) {
         return "";
     }
     auto session = state->session();
@@ -131,7 +131,7 @@ std::string SelectAction::shortText(InputContext *ic) const {
             return texts_[i];
         }
     }
-    return "";
+    return texts_[0];
 }
 
 std::optional<std::string> SelectAction::snapshotOption(InputContext *ic) {


### PR DESCRIPTION
Reproduce: use https://github.com/amzxyz/rime_wanxiang, in status area the label for [tone](https://github.com/amzxyz/rime_wanxiang/blob/4bf1750dd09ee4452af4f608e88df719e8d8963d/wanxiang.schema.yaml#L40) is empty. This is because there is no reset like [rime-cantonese](https://github.com/rime/rime-cantonese/blob/1c2da9400b4d5a1e976508ec27e9d287a34e2ee2/jyut6ping3.schema.yaml#L44).
However, pressing F4/Ctrl+` then 2 to show rime's options, there is a checkmark after the first option `raw_input`, which is the result of [GetSelectedOption](https://github.com/rime/librime/blob/0ce111459649ddf50960d76094b998ccc438db4b/src/rime/gear/switch_translator.cc#L145).
So adopt this behavior as well.