### PR TITLE
Allow configure preeditMode separately

### DIFF
--- a/src/rimeengine.h
+++ b/src/rimeengine.h
@@ -80,6 +80,8 @@ FCITX_CONFIGURATION(
     OptionWithAnnotation<PreeditMode, PreeditModeI18NAnnotation> preeditMode{
         this, "PreeditMode", _("Preedit Mode"),
         isAndroid() ? PreeditMode::No : PreeditMode::ComposingText};
+    OptionWithAnnotation<PreeditMode, PreeditModeI18NAnnotation> preeditModeUI{
+        this, "PreeditModeUI", _("Preedit Mode UI"), PreeditMode::No};
     OptionWithAnnotation<SharedStatePolicy, SharedStatePolicyI18NAnnotation>
         sharedStatePolicy{this, "InputState", _("Shared Input State"),
                           SharedStatePolicy::All};

--- a/src/rimestate.cpp
+++ b/src/rimestate.cpp
@@ -344,16 +344,34 @@ void RimeState::updatePreedit(InputContext *ic, const RimeContext &context) {
     PreeditMode mode = ic->capabilityFlags().test(CapabilityFlag::Preedit)
                            ? *engine_->config().preeditMode
                            : PreeditMode::No;
+    PreeditMode modeUI = ic->capabilityFlags().test(CapabilityFlag::Preedit)
+                           ? *engine_->config().preeditModeUI
+                           : PreeditMode::ComposingText;
+
+    switch (modeUI) {
+    case PreeditMode::No:
+        ic->inputPanel().setPreedit(Text());
+        break;
+    case PreeditMode::ComposingText:
+        ic->inputPanel().setPreedit(preeditFromRimeContext(
+            context, TextFormatFlag::NoFlag, TextFormatFlag::NoFlag));
+        break;
+    case PreeditMode::CommitPreview:
+        if (context.composition.length > 0 && context.commit_text_preview) {
+            Text preeditText;
+            preeditText.append(context.commit_text_preview);
+            ic->inputPanel().setPreedit(preeditText);
+        } else {
+            ic->inputPanel().setPreedit(Text());
+        }
+        break;
+    }
 
     switch (mode) {
     case PreeditMode::No:
-        ic->inputPanel().setPreedit(preeditFromRimeContext(
-            context, TextFormatFlag::NoFlag, TextFormatFlag::NoFlag));
         ic->inputPanel().setClientPreedit(Text());
         break;
     case PreeditMode::CommitPreview: {
-        ic->inputPanel().setPreedit(preeditFromRimeContext(
-            context, TextFormatFlag::NoFlag, TextFormatFlag::NoFlag));
         if (context.composition.length > 0 && context.commit_text_preview) {
             Text clientPreedit;
             clientPreedit.append(context.commit_text_preview,


### PR DESCRIPTION
This PR add a new option `preeditModeUI` to control the behavior of the preedit text on the floating window. and the origin `preeditMode` is used to control the embedded preedit text.

**(I have no idea how to name the two options, feel free to ask me for a rename)** 