### PR TITLE
Allow custom hints under the cursor when switching to English mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(PkgConfig REQUIRED)
 find_package(Pthread REQUIRED)
 
 if (NOT DEFINED RIME_TARGET)
-    pkg_check_modules(Rime REQUIRED IMPORTED_TARGET "rime>=1.7.0")
+    pkg_check_modules(Rime REQUIRED IMPORTED_TARGET "rime>=1.9.0")
     set(RIME_TARGET PkgConfig::Rime)
 endif()
 

--- a/src/rimeengine.h
+++ b/src/rimeengine.h
@@ -112,7 +112,10 @@ FCITX_CONFIGURATION(
         isApple() ? fcitx::KeyList{fcitx::Key("Control+Alt+grave")}
                   : fcitx::KeyList{}};
     fcitx::Option<fcitx::KeyList> synchronize{
-        this, "Synchronize", _("Synchronize"), {}};);
+        this, "Synchronize", _("Synchronize"), {}};
+    Option<bool> latinModeNameFromSchema{
+        this, "LatinModeNameFromSchema",
+        _("Use latin mode name defined in schema"), false};);
 
 class RimeEngine final : public InputMethodEngineV2 {
 public:

--- a/src/rimestate.cpp
+++ b/src/rimestate.cpp
@@ -74,13 +74,25 @@ void RimeState::clear() {
 
 void RimeState::activate() { maybeSyncProgramNameToSession(); }
 
+std::string RimeState::asciiModeName(bool abbrev) {
+    std::string result = abbrev ? "A" : _("Latin Mode");
+    if (engine_->config().latinModeNameFromSchema.value()) {
+        RimeStringSlice label = engine_->api()->get_state_label_abbreviated(
+            session(), "ascii_mode", True, abbrev);
+        if (label.str && label.length > 0) {
+            result.assign(label.str, label.length);
+        }
+    }
+    return result;
+}
+
 std::string RimeState::subMode() {
     std::string result;
-    getStatus([&result](const RimeStatus &status) {
+    getStatus([this, &result](const RimeStatus &status) {
         if (status.is_disabled) {
             result = "\xe2\x8c\x9b";
         } else if (status.is_ascii_mode) {
-            result = _("Latin Mode");
+            result = asciiModeName(/*abbrev=*/false);
         } else if (status.schema_name && status.schema_name[0] != '.') {
             result = status.schema_name;
         }
@@ -90,11 +102,12 @@ std::string RimeState::subMode() {
 
 std::string RimeState::subModeLabel() {
     std::string result;
-    getStatus([&result](const RimeStatus &status) {
+
+    getStatus([this, &result](const RimeStatus &status) {
         if (status.is_disabled) {
             result = "";
         } else if (status.is_ascii_mode) {
-            result = "A";
+            result = asciiModeName(/*abbrev=*/true);
         } else if (status.schema_name && status.schema_name[0] != '.') {
             result = status.schema_name;
             if (!result.empty() &&

--- a/src/rimestate.h
+++ b/src/rimestate.h
@@ -59,6 +59,7 @@ public:
     void showChangedOptions();
 
 private:
+    std::string asciiModeName(bool abbrev);
     void maybeSyncProgramNameToSession();
     std::vector<std::string> snapshotOptions(const std::string &schema);
 


### PR DESCRIPTION
For some people (like me), when switching to English mode, the prompt 'A' under the cursor might not be very satisfying. They feel that 'A' would be better used for the Caps Lock indicator, and the prompt for switching to English mode should use other text (like 'a').

At the moment, 'A' is hard-coded in the code, so it's not easy to change. This PR will allow users to customize this prompt in `~/.local/share/fcitx5/rime/fcitx5.custom.yaml`, for example:
```
patch:
"global_options/ascii_label": "a"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to use the Latin-mode name defined by the active schema.
  * Latin-mode labels now support both full and abbreviated display formats, with sensible fallback labels when no custom name is available.

* **Improvements**
  * Updated mode indicators to consistently reflect the configured Latin-mode naming across the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->