### PR TITLE
Fixed the issue where the Label prompt incorrectly detected the Caps Lock status.

### DIFF
--- a/src/rimestate.cpp
+++ b/src/rimestate.cpp
@@ -77,7 +77,7 @@ void RimeState::activate() { maybeSyncProgramNameToSession(); }
 std::string RimeState::asciiModeName(bool abbrev) {
     std::string result = _("Latin Mode");
     if (abbrev) {
-        result = engine_->isCapsLockOn(&ic_) ? "ABC" : "abc";
+        result = capsLock ? "ABC" : "abc";
     }
     if (engine_->config().latinModeNameFromSchema.value()) {
         RimeStringSlice label = engine_->api()->get_state_label_abbreviated(
@@ -195,6 +195,10 @@ void RimeState::keyEvent(KeyEvent &event) {
     auto states = event.rawKey().states() &
                   KeyStates{KeyState::Mod1, KeyState::CapsLock, KeyState::Shift,
                             KeyState::Ctrl, KeyState::Super};
+    capsLock = states.test(KeyState::CapsLock);
+    if (event.rawKey().sym() == FcitxKey_Caps_Lock && !event.isRelease()) {
+        capsLock = !capsLock;
+    }
     if (states.test(KeyState::Super)) {
         // IBus uses virtual super mask.
         states |= KeyState::Super2;

--- a/src/rimestate.h
+++ b/src/rimestate.h
@@ -71,6 +71,7 @@ private:
     std::string savedCurrentSchema_;
     std::vector<std::string> savedOptions_;
     std::vector<std::string> changedOptions_;
+    bool capsLock;
 };
 } // namespace fcitx::rime
 


### PR DESCRIPTION
Right now in the Label prompt, we use `RimeEngine::isCapsLockOn` to check the current Caps Lock status, but the status we get from this function is delayed too much for the Label, so it doesn't work at all.
```
result = engine_->isCapsLockOn(&ic_) ? "ABC" : "abc";
```
The code above basically always returns `abc`, it won't ever give `ABC`.

This PR fixes the problem of excessive delay by getting the caps lock state through `RimeState::keyEvent`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Caps Lock state tracking during key processing.
  * ASCII mode labels now accurately reflect the current Caps Lock state, including toggles from keyboard events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->