### PR TITLE
When entering ASCII mode using the Caps Lock key, change the custom label prompt to uppercase

### DIFF
--- a/src/rimeengine.h
+++ b/src/rimeengine.h
@@ -116,7 +116,9 @@ FCITX_CONFIGURATION(
         this, "Synchronize", _("Synchronize"), {}};
     Option<bool> latinModeNameFromSchema{
         this, "LatinModeNameFromSchema",
-        _("Use latin mode name defined in schema"), false};);
+        _("Use latin mode name defined in schema"), false};
+    Option<std::string> capsLockLabelPrompt{
+        this, "CapsLockLabelPrompt", _("Caps Lock label prompt"), "ABC"};);
 
 class RimeEngine final : public InputMethodEngineV2 {
 public:

--- a/src/rimestate.cpp
+++ b/src/rimestate.cpp
@@ -77,7 +77,7 @@ void RimeState::activate() { maybeSyncProgramNameToSession(); }
 std::string RimeState::asciiModeName(bool abbrev) {
     std::string result = _("Latin Mode");
     if (abbrev) {
-        result = engine_->isCapsLockOn(&ic_) ? "ABC" : "abc";
+        result = "abc";
     }
     if (engine_->config().latinModeNameFromSchema.value()) {
         RimeStringSlice label = engine_->api()->get_state_label_abbreviated(
@@ -85,6 +85,11 @@ std::string RimeState::asciiModeName(bool abbrev) {
         if (label.str && label.length > 0) {
             result.assign(label.str, label.length);
         }
+    }
+    if (abbrev) {
+        result = engine_->isCapsLockOn(&ic_)
+                     ? engine_->config().capsLockLabelPrompt.value()
+                     : result;
     }
     return result;
 }


### PR DESCRIPTION
Currently, the Caps Lock label tip only appears when 'Use latin mode name defined in schema' is not enabled.

This feature would allow the Caps Lock label tip to show even when 'Use latin mode name defined in schema' is enabled.

It works by flipping the original tip to uppercase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added a configurable prompt label for Latin mode when Caps Lock is active.
- The default Caps Lock label is “ABC,” with support for custom labels, including schema-provided values.

## Bug Fixes

- Latin mode now consistently displays “abc” when Caps Lock is inactive.
- Caps Lock correctly replaces the abbreviated Latin-mode label with the configured prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->