### PR TITLE
add option to reset global status to app_option on focus change

### DIFF
--- a/src/rimeengine.h
+++ b/src/rimeengine.h
@@ -116,7 +116,10 @@ FCITX_CONFIGURATION(
         this, "Synchronize", _("Synchronize"), {}};
     Option<bool> latinModeNameFromSchema{
         this, "LatinModeNameFromSchema",
-        _("Use latin mode name defined in schema"), false};);
+        _("Use latin mode name defined in schema"), false};
+    Option<bool> applyAppOptionOnFocusChange{
+        this, "ApplyAppOptionOnFocusChange",
+        _("Apply app_option to status on focus change"), false};);
 
 class RimeEngine final : public InputMethodEngineV2 {
 public:

--- a/src/rimesession.cpp
+++ b/src/rimesession.cpp
@@ -64,8 +64,21 @@ void RimeSessionHolder::setProgramName(const std::string &program) {
         return;
     }
 
+    auto *api = pool_->engine()->api();
+
     currentProgram_ = program;
-    pool_->engine()->api()->set_property(id_, "client_app", program.data());
+    api->set_property(id_, "client_app", program.data());
+
+    if (pool_->engine()->config().applyAppOptionOnFocusChange.value()) {
+        const auto &appOptions = pool_->engine()->appOptions();
+        if (auto iter = appOptions.find(program); iter != appOptions.end()) {
+            RIME_DEBUG() << "Apply app options to " << program << ": "
+                         << iter->second;
+            for (const auto &[key, value] : iter->second) {
+                api->set_option(id_, key.data(), value);
+            }
+        }
+    }
 }
 
 #if 0


### PR DESCRIPTION
Allow the state defined by `app_option` to be applied to the global input method state when the focused app changes

This feature, compared to `app_option` which is only used for initial sessions, has the advantage of being predictable.

Imagine the following scenario:

```
patch:
"app_options/org.kde.kate
ascii_mode: true
```

The shared input state is set to programs.

You have two programs open, one is `firefox` and the other is the `kate` editor.

Now your focus is on `firefox`, and next you want to switch focus to `kate`. How would you know if the current input state is ASCII mode?

Check the status bar? Check it every time you switch? That’s way too tedious.

Remember each app's input state in your head? Who would do that? It’s cognitively demanding and easy to get wrong (even if the state was globally unique, I wouldn’t bother remembering it, let alone multiple states :-)

This feature was born to solve the problem above.

Set the shared input state to global.

In `app_options` set the state you want.

Then turn on this feature.

This way, every time you switch to the specified app, the input method state is clear in your mind, with basically no cognitive load, and you don’t have to move your eyes to the status bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to reapply application-specific input options when switching focus between applications.
  * The setting is disabled by default and can be enabled in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->